### PR TITLE
update load_image: add msra support & speedup nyu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ demo-cpp
 *.gif
 *.caffemodel
 .spyproject*
+.idea
+training
+caffe-pose

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ python evaluation/compute_error.py icvl results/icvl_ren_9x6x6.txt
 ## Visualization
 Please use the Python script `evaluation/show_result.py` for visualziation, which also requires [OpenCV](http://opencv.org/):
 ``` bash
-$ python evaluation/show_result.py icvl --in_file=results/icvl_ren_4x6x6.txt
+$ python evaluation/show_result.py icvl your/path/to/ICVL/images/test/Depth --in_file=results/icvl_ren_4x6x6.txt
 ```
 You can see all the testing results on the images. Press 'q' to exit.
 


### PR DESCRIPTION
1. add support for loading images for MSRA dataset
2. optimize the speed of loading images for NYU dataset using numpy bitwise function instead of "for" loop (much faster now)
3. update Readme